### PR TITLE
Correct broken link

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@ Describe your issue here.
 - [ ] discussion
 
 ### Requirements (place an `x` in each of the `[ ]`)
-* [ ] I've read and understood the [Contributing guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/goSDL/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 


### PR DESCRIPTION
###  Summary

The contributing link was broken and is now fixed. The CLA link is also broken, and so I have not signed it... point me to it and I'll fix that as well if you like :)

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
