### PR TITLE
fixed a bug which ignores submodule selections

### DIFF
--- a/include/lib_sdl.php
+++ b/include/lib_sdl.php
@@ -27,7 +27,7 @@
 				$infoobj['submodules'] = array();
 				foreach ($parsed['submodules'] as $submod){
 					$infoobj2 = array(
-						"filename" => $filename,
+						"filename" => $filename.md5($filename.$submod['title']),
 						"title" => $submod['title'],
 						"description" => $submod['description'],
 					);


### PR DESCRIPTION
The submodules were correctly having a digest of their title appended to the filename in one place, but not in another.
