### PR TITLE
Remove superfluous require

### DIFF
--- a/include/lib_smarty.php
+++ b/include/lib_smarty.php
@@ -14,8 +14,6 @@
 	$GLOBALS['cfg']['smarty_compile']	= true;
 	$GLOBALS['cfg']['smarty_force_compile']	= true;
 
-	require '../vendor/smarty/smarty/libs/Smarty.class.php';
-
 	$GLOBALS['smarty'] = new Smarty();
 	$GLOBALS['smarty']->template_dir = $GLOBALS['cfg']['smarty_template_dir'];
 	$GLOBALS['smarty']->compile_dir  = $GLOBALS['cfg']['smarty_compile_dir'];


### PR DESCRIPTION
Requiring the composer autoload.php will load the Smarty class

###  Summary

Removes a superfluous

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/goSDL/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/goSDL).
