### PR TITLE
Fix wrong port for docker deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Settings:
 ### Usage with docker
 1. Build locally: `docker build -t gosdl .`
 
-2. Run it: `docker run -ti --rm --env-file <your dotenv> -p 8080:8080 gosdl`
+2. Run it: `docker run -ti --rm --env-file <your dotenv> -p 8000:8080 gosdl`
 
 3. Visit http://localhost:8000/sdl.php
 


### PR DESCRIPTION
###  Summary

This fixes the wrong port described in README.md for docker deployment.
changed from 8080 to 8000

### Requirements (place an `x` in each `[ ]`)

* [ X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/goSDL/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ X] I've written tests to cover the new code and functionality included in this PR.

* [ X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/goSDL).
